### PR TITLE
Don't send a new response when it isn't an ElasticSearch.errors._Abst…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ exports.register = function (plugin, options, next) {
         if (response instanceof ElasticSearch.errors._Abstract) {
             rep(Boom.create(response.status, response.message, response));
         } else {
-            rep(response);
+            rep.continue();
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-elastic",
   "description": "Elastic Search Hapi Plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "keywords": [
     "hapi",
     "plugin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-elastic",
   "description": "Elastic Search Hapi Plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "keywords": [
     "hapi",
     "plugin",
@@ -25,11 +25,11 @@
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "hapi": ">= 9.x.x",
-    "elasticsearch": "^11.0.1"
+    "elasticsearch": "^15.1.1"
   },
   "dependencies": {
     "boom": "^2.8.0",
-    "elasticsearch": "^11.0.1",
+    "elasticsearch": "^15.1.1",
     "hoek": "^2.14.0",
     "joi": "^6.6.1"
   },
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "code": "^1.5.0",
-    "elasticsearch": "^11.0.1",
+    "elasticsearch": "^15.1.1",
     "hapi": "^9.0.3",
     "lab": "^5.15.2"
   }


### PR DESCRIPTION
…ract

Using rep(response) sends a new response, whereas using rep.continue()
does not impact the response's lifecycle.

See: http://hapijs.com/api#request-lifecycle

---

I was using hapi's response validation feature, and using `rep(response)` skips this step.
